### PR TITLE
feat: add --help-json flag for AI agent usage info

### DIFF
--- a/cmd/helpjson.go
+++ b/cmd/helpjson.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// CommandHelp is the JSON schema for a CLI command, intended for AI agent consumption.
+type CommandHelp struct {
+	Name        string        `json:"name"`
+	Use         string        `json:"use"`
+	Short       string        `json:"short"`
+	Long        string        `json:"long,omitempty"`
+	Aliases     []string      `json:"aliases,omitempty"`
+	Flags       []FlagHelp    `json:"flags,omitempty"`
+	Subcommands []CommandHelp `json:"subcommands,omitempty"`
+}
+
+// FlagHelp is the JSON schema for a CLI flag.
+type FlagHelp struct {
+	Name      string `json:"name"`
+	Shorthand string `json:"shorthand,omitempty"`
+	Usage     string `json:"usage"`
+	Default   string `json:"default,omitempty"`
+	Type      string `json:"type"`
+}
+
+var skipHelpFlags = map[string]bool{
+	"help":      true,
+	"help-json": true,
+	"version":   true,
+}
+
+func buildCommandHelp(cmd *cobra.Command) CommandHelp {
+	h := CommandHelp{
+		Name:  cmd.Name(),
+		Use:   cmd.Use,
+		Short: cmd.Short,
+		Long:  strings.TrimSpace(cmd.Long),
+	}
+	if len(cmd.Aliases) > 0 {
+		h.Aliases = cmd.Aliases
+	}
+
+	seen := map[string]bool{}
+	addFlag := func(f *pflag.Flag) {
+		if skipHelpFlags[f.Name] || seen[f.Name] {
+			return
+		}
+		seen[f.Name] = true
+		h.Flags = append(h.Flags, FlagHelp{
+			Name:      f.Name,
+			Shorthand: f.Shorthand,
+			Usage:     f.Usage,
+			Default:   f.DefValue,
+			Type:      f.Value.Type(),
+		})
+	}
+
+	cmd.Flags().VisitAll(addFlag)
+	cmd.PersistentFlags().VisitAll(addFlag)
+
+	for _, sub := range cmd.Commands() {
+		if sub.Hidden || sub.Name() == "help" {
+			continue
+		}
+		h.Subcommands = append(h.Subcommands, buildCommandHelp(sub))
+	}
+
+	return h
+}
+
+func outputHelpJSON(cmd *cobra.Command) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(buildCommandHelp(cmd))
+	os.Exit(0)
+}
+
+// checkHelpJSON inspects os.Args for --help-json before cobra parses flags.
+// If found, it resolves the target command from the non-flag positional args,
+// prints its JSON help, and exits.
+func checkHelpJSON() {
+	args := os.Args[1:]
+	found := false
+	for _, a := range args {
+		if a == "--help-json" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return
+	}
+
+	var cmdArgs []string
+	for _, a := range args {
+		if a == "--help-json" || strings.HasPrefix(a, "-") {
+			continue
+		}
+		cmdArgs = append(cmdArgs, a)
+	}
+
+	targetCmd, _, _ := rootCmd.Find(cmdArgs)
+	if targetCmd == nil {
+		targetCmd = rootCmd
+	}
+	outputHelpJSON(targetCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,6 +114,7 @@ Checks for:
 
 func init() {
 	rootCmd.Version = version.Version
+	rootCmd.PersistentFlags().Bool("help-json", false, "Output help as JSON for AI agent consumption")
 	checkCmd.Flags().StringVarP(&format, "format", "f", "pretty", "Output format: pretty, json, or toon")
 	checkCmd.Flags().StringVar(&outputFormat, "output", "", "Output format (alias for --format): pretty, json, or toon")
 	checkCmd.Flags().StringSliceVarP(&languages, "lang", "l", nil, "Languages to check (go, python). Auto-detects if not specified.")
@@ -157,6 +158,8 @@ func Execute() {
 	// print errors, so commands can return errors instead of calling os.Exit.
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
+
+	checkHelpJSON()
 
 	if err := rootCmd.Execute(); err != nil {
 		if !errors.Is(err, errSilent) {


### PR DESCRIPTION
Adds a --help-json persistent flag to a2 that outputs machine-readable JSON describing all commands, their flags, and descriptions. Works on the root command (a2 --help-json) and any subcommand (a2 check --help-json). The flag intercepts os.Args before cobra runs so it works even on commands without a Run function (like `a2 profiles --help-json`).